### PR TITLE
Update FormHelper.php

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -353,7 +353,7 @@ class FormHelper extends AppHelper {
 		}
 
 		$options = array_merge(array(
-			'type' => ($created && empty($options['action'])) ? 'put' : 'post',
+			'type' => ($created && (empty($options['action']) || empty($options['url']))) ? 'put' : 'post',
 			'action' => null,
 			'url' => null,
 			'default' => true,


### PR DESCRIPTION
options['url'] must be verified too, because $options['action'] is deprecated.

See cakephp-2.9.6/lib/Cake/View/Helper/FormHelper.php Line 382